### PR TITLE
Add is_lightning to the damage flags

### DIFF
--- a/src/shared/predicate.json
+++ b/src/shared/predicate.json
@@ -67,6 +67,9 @@
                 "is_fire": {
                     "type": "boolean"
                 },
+                "is_lightning": {
+                    "type": "boolean"
+                },
                 "is_magic": {
                     "type": "boolean"
                 },


### PR DESCRIPTION
I don't know if you need to change anything in `./scripts/convert.js` for this, but the damage flags were missing is_lightning.